### PR TITLE
Update sta1_test.go

### DIFF
--- a/_test/sta1/sta1_test.go
+++ b/_test/sta1/sta1_test.go
@@ -19,7 +19,7 @@ func TestStation1(t *testing.T) {
 		return
 	}
 
-	if !regexp.MustCompile(`go\sversion\sgo1\.\d+\.\d+\s.+/.+`).Match(w.Bytes()) {
+	if !regexp.MustCompile(`go\sversion\sgo1\.\d+(\.\d+)?\s.+/.+`).Match(w.Bytes()) {
 		t.Error("go version の実行結果に問題があります")
 		return
 	}


### PR DESCRIPTION
Goのパッチバージョンがない場合にテストに失敗する問題を修正．