### PR TITLE
replace int to float64

### DIFF
--- a/_test/sta9/sta9_test.go
+++ b/_test/sta9/sta9_test.go
@@ -111,7 +111,7 @@ func TestStation9(t *testing.T) {
 			diff := cmp.Diff(got, want, cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
 				switch k {
 				case "id":
-					if vv, _ := v.(int); vv == 0 {
+					if vv, _ := v.(float64); vv == 0 {
 						t.Errorf("id を数値に変換できません, got = %s", k)
 					}
 					return true


### PR DESCRIPTION
型アサーションの修正

jsonをinterfaceにdecodeする際、Numberはfloat64にdecodeされるため、float64でassertするように修正しました．
https://pkg.go.dev/encoding/json#Unmarshal