### PR TITLE
fix: add dependency for go-cmp and fix assert error type

### DIFF
--- a/_test/sta12/sta12_test.go
+++ b/_test/sta12/sta12_test.go
@@ -59,14 +59,10 @@ func TestStation12(t *testing.T) {
 		ID          int64
 		Subject     string
 		Description string
-		WantError   error
 	}{
-		"ID is empty": {
-			WantError: &model.ErrNotFound{},
-		},
+		"ID is empty": {},
 		"Subject is empty": {
-			ID:        1,
-			WantError: sqlite3.ErrConstraint,
+			ID: 1,
 		},
 		"Description is empty": {
 			ID:      1,
@@ -79,23 +75,20 @@ func TestStation12(t *testing.T) {
 		},
 	}
 
+	var sqlite3Err sqlite3.Error
+
 	for name, tc := range testcases {
 		name := name
 		tc := tc
 		t.Run(name, func(t *testing.T) {
 			svc := service.NewTODOService(d)
 			got, err := svc.UpdateTODO(context.Background(), tc.ID, tc.Subject, tc.Description)
-			switch tc.WantError {
-			case nil:
-				if err != nil {
-					t.Errorf("予期しないエラーが発生しました: %v", err)
+			if err != nil {
+				if !errors.As(err, &sqlite3Err) {
+					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 					return
 				}
-			default:
-				if !errors.As(err, &tc.WantError) {
-					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, tc.WantError)
-					return
-				}
+				t.Errorf("予期しないエラーが発生しました: %v", err)
 				return
 			}
 

--- a/_test/sta8/sta8_test.go
+++ b/_test/sta8/sta8_test.go
@@ -22,11 +22,8 @@ func TestStation8(t *testing.T) {
 	testcases := map[string]struct {
 		Subject     string
 		Description string
-		WantError   error
 	}{
-		"Subject is empty": {
-			WantError: sqlite3.ErrConstraint,
-		},
+		"Subject is empty": {},
 		"Description is empty": {
 			Subject: "todo subject",
 		},
@@ -54,6 +51,8 @@ func TestStation8(t *testing.T) {
 		}
 	})
 
+	var sqlite3Err sqlite3.Error
+
 	for name, tc := range testcases {
 		name := name
 		tc := tc
@@ -62,16 +61,11 @@ func TestStation8(t *testing.T) {
 
 			svc := service.NewTODOService(d)
 			got, err := svc.CreateTODO(context.Background(), tc.Subject, tc.Description)
-			switch tc.WantError {
-			case nil:
-				if err != nil {
-					t.Error("エラーが発生しました", err)
-					return
+			if err != nil {
+				if !errors.As(err, &sqlite3Err) {
+					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 				}
-			default:
-				if !errors.As(err, &tc.WantError) {
-					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, tc.WantError)
-				}
+				t.Error("エラーが発生しました", err)
 				return
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/TechBowl-japan/go-stations
 go 1.16
 
 require (
+	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1
 	github.com/mattn/go-sqlite3 v1.14.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=


### PR DESCRIPTION
## PR改善の内容

https://railwayco.slack.com/archives/C028CS4S6JH/p1669190012764419
上記のスレッドでいただいたgo-stationsのバグ(go.modにgo-cmpの依存がない、errors.Asで型ではなく値としてチェックしている)をちょうどみていて見つけたため下記のPRで対応しました
確認お願いします