### PR TITLE
Fix/test error check

### DIFF
--- a/_test/sta12/sta12_test.go
+++ b/_test/sta12/sta12_test.go
@@ -88,7 +88,6 @@ func TestStation12(t *testing.T) {
 					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 					return
 				}
-				t.Errorf("予期しないエラーが発生しました: %v", err)
 				return
 			}
 

--- a/_test/sta8/sta8_test.go
+++ b/_test/sta8/sta8_test.go
@@ -65,7 +65,6 @@ func TestStation8(t *testing.T) {
 				if !errors.As(err, &sqlite3Err) {
 					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 				}
-				t.Error("エラーが発生しました", err)
 				return
 			}
 


### PR DESCRIPTION
関連PR：https://github.com/TechBowl-japan/go-stations/pull/28

関連PRでエラーを返すことを想定しているテストで想定しているエラー( `sqlite3.Error` ) が返ってきた場合でもテストが通らなくなっていたため修正しました．