### PR TITLE
assert error number

### DIFF
--- a/_test/sta12/sta12_test.go
+++ b/_test/sta12/sta12_test.go
@@ -88,6 +88,10 @@ func TestStation12(t *testing.T) {
 					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 					return
 				}
+				if err.(sqlite3.Error).Code != sqlite3.ErrConstraint {
+					t.Errorf("期待していないsqlite3のエラーナンバーです, got = %d, want = %d", err.(sqlite3.Error).Code, sqlite3.ErrConstraint)
+					return
+				}
 				return
 			}
 

--- a/_test/sta8/sta8_test.go
+++ b/_test/sta8/sta8_test.go
@@ -65,6 +65,10 @@ func TestStation8(t *testing.T) {
 				if !errors.As(err, &sqlite3Err) {
 					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 				}
+				if err.(sqlite3.Error).Code != sqlite3.ErrConstraint {
+					t.Errorf("期待していないsqlite3のエラーナンバーです, got = %d, want = %d", err.(sqlite3.Error).Code, sqlite3.ErrConstraint)
+					return
+				}
 				return
 			}
 


### PR DESCRIPTION
以前まで想定していたエラー
https://github.com/mattn/go-sqlite3/blob/1603038a4dc1f945229836bc49aa448f571ab288/error.go#L56
と異なるエラーナンバーでも型が同じならテストが通るようになっているので、エラーナンバーの比較を追加しました．