### PR TITLE
Fix/go vet after go1.19

### DIFF
--- a/_test/sta18/sta18_test.go
+++ b/_test/sta18/sta18_test.go
@@ -2,8 +2,8 @@ package sta18_test
 
 import (
 	"context"
-	"errors"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/TechBowl-japan/go-stations/db"
@@ -100,7 +100,7 @@ func TestStation18(t *testing.T) {
 					return
 				}
 			default:
-				if !errors.As(err, &tc.WantError) {
+				if reflect.TypeOf(err) != reflect.TypeOf(tc.WantError) {
 					t.Errorf("期待していないエラーの型です, got = %+v, want = %+v", err, tc.WantError)
 					return
 				}

--- a/_test/sta8/sta8_test.go
+++ b/_test/sta8/sta8_test.go
@@ -62,7 +62,7 @@ func TestStation8(t *testing.T) {
 			svc := service.NewTODOService(d)
 			got, err := svc.CreateTODO(context.Background(), tc.Subject, tc.Description)
 			if err != nil {
-				if !errors.As(err, sqlite3Err) {
+				if !errors.As(err, &sqlite3Err) {
 					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 				}
 				if err.(sqlite3.Error).Code != sqlite3.ErrConstraint {

--- a/_test/sta8/sta8_test.go
+++ b/_test/sta8/sta8_test.go
@@ -2,8 +2,8 @@ package sta8_test
 
 import (
 	"context"
+	"errors"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -62,7 +62,7 @@ func TestStation8(t *testing.T) {
 			svc := service.NewTODOService(d)
 			got, err := svc.CreateTODO(context.Background(), tc.Subject, tc.Description)
 			if err != nil {
-				if reflect.TypeOf(err) != reflect.TypeOf(sqlite3Err) {
+				if !errors.As(err, sqlite3Err) {
 					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 				}
 				if err.(sqlite3.Error).Code != sqlite3.ErrConstraint {

--- a/_test/sta8/sta8_test.go
+++ b/_test/sta8/sta8_test.go
@@ -2,8 +2,8 @@ package sta8_test
 
 import (
 	"context"
-	"errors"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -62,7 +62,7 @@ func TestStation8(t *testing.T) {
 			svc := service.NewTODOService(d)
 			got, err := svc.CreateTODO(context.Background(), tc.Subject, tc.Description)
 			if err != nil {
-				if !errors.As(err, &sqlite3Err) {
+				if reflect.TypeOf(err) != reflect.TypeOf(sqlite3Err) {
 					t.Errorf("期待していないエラーの Type です, got = %t, want = %+v", err, sqlite3Err)
 				}
 				if err.(sqlite3.Error).Code != sqlite3.ErrConstraint {


### PR DESCRIPTION
errors.Asの第2引数に *error 型を渡していたため、testが実行できなくなっていました．
原因を調べると、Go1.19から上記内容がvetで弾かれるようになったようです．

そこで関連PRと同様に明示的に型の比較を行うように修正しました．

関連：https://github.com/TechBowl-japan/go-stations/pull/33

確認お願いします:bow: