### PR TITLE
fix multiple route

### DIFF
--- a/_test/sta5/sta5_test.go
+++ b/_test/sta5/sta5_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/TechBowl-japan/go-stations/db"
-	"github.com/TechBowl-japan/go-stations/handler"
 	"github.com/TechBowl-japan/go-stations/handler/router"
 )
 
@@ -37,8 +36,6 @@ func TestStation5(t *testing.T) {
 	})
 
 	r := router.NewRouter(todoDB)
-	h := handler.NewHealthzHandler()
-	r.Handle("/healthz", h)
 	srv := httptest.NewServer(r)
 	defer srv.Close()
 	req, err := http.NewRequest(http.MethodGet, srv.URL+"/healthz", nil)


### PR DESCRIPTION
main.go で 　`// NOTE: 新しいエンドポイントの登録はrouter.NewRouterの内部で行うようにする` とあるが、sta5_test.go で再度エンドポイントを定義しているので router.NewRouter 内でhealthzのエンドポイントを定義しているとエラーになるのでその修正

ref : https://github.com/TechTrain-Community/RailwayForum/discussions/16