### PR TITLE
fix id check station9

### DIFF
--- a/_test/sta9/sta9_test.go
+++ b/_test/sta9/sta9_test.go
@@ -116,8 +116,12 @@ func TestStation9(t *testing.T) {
 			diff := cmp.Diff(got, want, cmpopts.IgnoreMapEntries(func(k string, v interface{}) bool {
 				switch k {
 				case "id":
-					if vv, _ := v.(float64); vv == 0 {
+					vv, ok := v.(float64);
+					if !ok {
 						t.Errorf("id を数値に変換できません, got = %s", k)
+					}
+					if vv == 0 {
+						t.Errorf("id が初期値になっています, got = %d", vv)
 					}
 					return true
 				case "created_at", "updated_at":


### PR DESCRIPTION
## 概要

idのチェックに関して、id が初期値の場合も`id を数値に変換できません`が出てしまっていたため、テストがなぜ落ちたかをわかりやすくする対応