### PR TITLE
fix: typo README.md & openapi.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SQLite| 3.35.* or higher
 |Yarn|1.22.*|
 
 バージョンが異なる場合、動作しない場合があります。  
-Node.js, Yarnのインストールがまだの場合は[html-staions](https://github.com/TechBowl-japan/html-stations)を参考にインストールしてください。  
+Node.js, Yarnのインストールがまだの場合は[html-stations](https://github.com/TechBowl-japan/html-stations)を参考にインストールしてください。  
 また、使用PCがWindowsの場合は、WSLを[この記事](https://docs.microsoft.com/ja-jp/windows/wsl/install-win10)を参考にインストールしてください。
 
 ### 「必要なツール」インストール済みの場合

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -146,6 +146,6 @@ components:
         created_at:
           type: string
           format: date-time
-        updateed_at:
+        updated_at:
           type: string
           format: date-time


### PR DESCRIPTION
### タイポと思われるものを修正しています
- ./README.md:26:34
    - 正しくは`stations`と思われるが，`staions`になっている
- ./docs/openapi.yaml:149:9
    - 正しくは`updated_at`と思われるが，`updateed_at`になっている

### 経緯
タイポチェックツールにより検出しました． 