### PR TITLE
pre-commit削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,20 +4,5 @@
   "main": "index.js",
   "license": "MIT",
   "repository": "https://github.com/TechBowl-japan/go-stations.git",
-  "author": "Hikaru Terazono (3c1u) <3c1u@tohkani.com>",
-  "dependencies": {
-    "@techtrain/cli-railway": "0.1.3"
-  },
-  "devDependencies": {
-    "simple-git-hooks": "^2.5.1"
-  },
-  "scripts": {
-    "login:techtrain": "techtrain-railway login",
-    "hook:pre-commit": "techtrain-railway hook:pre-commit",
-    "hook:update": "simple-git-hooks",
-    "postinstall": "yarn hook:update && yarn login:techtrain"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "yarn hook:pre-commit"
-  }
+  "author": "Hikaru Terazono (3c1u) <3c1u@tohkani.com>"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,3 @@
 # yarn lockfile v1
 
 
-"@techtrain/cli-railway@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@techtrain/cli-railway/-/cli-railway-0.1.3.tgz#ca6151f0cbe4ba163ae1373bcc43c71cc13da0bf"
-  integrity sha512-k+z93v7bLFEh0HXmz130Fkuh+TCuU4Q0vw5FacAPT8XHHftp15xgDfltZOm8Yw/x16zIpjXsDxzZNGj6C6d8iA==
-
-simple-git-hooks@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/simple-git-hooks/-/simple-git-hooks-2.5.1.tgz#78ed9cfa552843bc45cd36ad5b7424567119c2f4"
-  integrity sha512-iI/MEEVObv45slsxz+BT+5NCS2UDgVIqfQKmNjL4/XnEfacpdYAHd71Imc5Nw/FY100A+i1PIXdIdkLHYcC2Bg==


### PR DESCRIPTION
現在Railwayのユニットテストの合格判定はVSCode拡張から行なっているので、railway-cliやpre-commitによる判定自動実行が不要なので削除しました。