### PR TITLE
Goのバージョンを1.24に上げる

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/TechBowl-japan/go-stations
 
-go 1.16
+go 1.21
+
+toolchain go1.24.0
 
 require (
 	github.com/google/go-cmp v0.5.9 // indirect


### PR DESCRIPTION
Goのバージョンを1.24に上げる対応をしました．

なるべくユーザーの作業が増えないように、1.21以上であれば使えるgo toolchainを使ってバージョンを管理するようにしています．